### PR TITLE
Fix concurrent dictionary access bugs

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '11.0'
+platform :ios, '13.0'
 use_frameworks!
 
 target 'PropertyInjector_Example' do
@@ -7,7 +7,7 @@ target 'PropertyInjector_Example' do
   target 'PropertyInjector_Tests' do
     inherit! :search_paths
 
-    pod 'Quick', '~> 1.2.0'
-    pod 'Nimble', '~> 7.0'
+    pod 'Quick', '~> 7.3'
+    pod 'Nimble', '~> 13.0'
   end
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
-  - Nimble (7.3.4)
-  - PropertyInjector (0.0.5)
-  - Quick (1.2.0)
+  - Nimble (13.0.0)
+  - PropertyInjector (0.0.11)
+  - Quick (7.3.0)
 
 DEPENDENCIES:
-  - Nimble (~> 7.0)
+  - Nimble (~> 13.0)
   - PropertyInjector (from `../`)
-  - Quick (~> 1.2.0)
+  - Quick (~> 7.3)
 
 SPEC REPOS:
   trunk:
@@ -18,10 +18,10 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
-  PropertyInjector: c017b64e27727c1948e693d8dd141a64cb23a8fe
-  Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
+  Nimble: 97d90931cca412a23224ff29e258809f75c258f7
+  PropertyInjector: a4e9996a307588f21ac48e9c083951916bcc6098
+  Quick: d32871931c05547cb4e0bc9009d66a18b50d8558
 
-PODFILE CHECKSUM: b2b3d69c84075b0f90f75676d91d212b149a9a4d
+PODFILE CHECKSUM: 1b4cc00efb7dd5dac8938d4936c5f959a45bf180
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.1

--- a/Example/Pods/Local Podspecs/PropertyInjector.podspec.json
+++ b/Example/Pods/Local Podspecs/PropertyInjector.podspec.json
@@ -1,8 +1,8 @@
 {
   "name": "PropertyInjector",
-  "version": "0.0.5",
-  "summary": "Property dependency injection micro framework for Swift.",
-  "description": "Property dependency injection framework for Swift 5.1+ and iOS 11+.\nJust declare a dependency as a property in your class and use @Inject property wrapper for it to be resolved on demand.",
+  "version": "0.0.11",
+  "summary": "Property dependency injection framework for Swift.",
+  "description": "Property dependency injection framework for Swift 5.1+ and iOS 11+.\nDeclare your dependencies and use them as properties in your classes.",
   "homepage": "https://github.com/stanfeldman/PropertyInjector",
   "license": {
     "type": "MIT",
@@ -13,12 +13,12 @@
   },
   "source": {
     "git": "https://github.com/stanfeldman/PropertyInjector.git",
-    "tag": "0.0.5"
+    "tag": "0.0.11"
   },
-  "swift_versions": "5.1",
+  "swift_versions": "5.5",
   "platforms": {
-    "ios": "11.0"
+    "ios": "13.0"
   },
   "source_files": "PropertyInjector/Classes/**/*",
-  "swift_version": "5.1"
+  "swift_version": "5.5"
 }

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,12 +1,12 @@
 PODS:
-  - Nimble (7.3.4)
-  - PropertyInjector (0.0.5)
-  - Quick (1.2.0)
+  - Nimble (13.0.0)
+  - PropertyInjector (0.0.11)
+  - Quick (7.3.0)
 
 DEPENDENCIES:
-  - Nimble (~> 7.0)
+  - Nimble (~> 13.0)
   - PropertyInjector (from `../`)
-  - Quick (~> 1.2.0)
+  - Quick (~> 7.3)
 
 SPEC REPOS:
   trunk:
@@ -18,10 +18,10 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
-  PropertyInjector: c017b64e27727c1948e693d8dd141a64cb23a8fe
-  Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
+  Nimble: 97d90931cca412a23224ff29e258809f75c258f7
+  PropertyInjector: a4e9996a307588f21ac48e9c083951916bcc6098
+  Quick: d32871931c05547cb4e0bc9009d66a18b50d8558
 
-PODFILE CHECKSUM: b2b3d69c84075b0f90f75676d91d212b149a9a4d
+PODFILE CHECKSUM: 1b4cc00efb7dd5dac8938d4936c5f959a45bf180
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.1

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -1101,7 +1101,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.1;
+				SWIFT_VERSION = "5.5";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1330,7 +1330,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.1;
+				SWIFT_VERSION = "5.5";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -1093,7 +1093,7 @@
 				GCC_PREFIX_HEADER = "Target Support Files/PropertyInjector/PropertyInjector-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/PropertyInjector/PropertyInjector-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/PropertyInjector/PropertyInjector.modulemap";
 				PRODUCT_MODULE_NAME = PropertyInjector;
@@ -1322,7 +1322,7 @@
 				GCC_PREFIX_HEADER = "Target Support Files/PropertyInjector/PropertyInjector-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/PropertyInjector/PropertyInjector-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/PropertyInjector/PropertyInjector.modulemap";
 				PRODUCT_MODULE_NAME = PropertyInjector;

--- a/Example/PropertyInjector.xcodeproj/project.pbxproj
+++ b/Example/PropertyInjector.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		210BABBE2AE56B6D00641DB4 /* Pods_PropertyInjector_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 758A7C8295F68F44E95E1D16 /* Pods_PropertyInjector_Example.framework */; };
 		4C742F0C24DEF025003531E8 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4C742F0B24DEF025003531E8 /* Main.storyboard */; };
 		4C742F0E24DEF1E1003531E8 /* DependencyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C742F0D24DEF1E1003531E8 /* DependencyManager.swift */; };
 		4C742F1C24DEF5A7003531E8 /* Dependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C742F1B24DEF5A7003531E8 /* Dependencies.swift */; };
@@ -14,7 +15,6 @@
 		607FACD81AFB9204008FA782 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* ViewController.swift */; };
 		607FACEC1AFB9204008FA782 /* PropertyInjectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* PropertyInjectorTests.swift */; };
 		AA0FD559196533EE2D5D5019 /* Pods_PropertyInjector_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C54194E9FF47E0B5520F1CF5 /* Pods_PropertyInjector_Tests.framework */; };
-		DDA312EDD41909C86153D0A5 /* Pods_PropertyInjector_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 758A7C8295F68F44E95E1D16 /* Pods_PropertyInjector_Example.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,7 +54,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DDA312EDD41909C86153D0A5 /* Pods_PropertyInjector_Example.framework in Frameworks */,
+				210BABBE2AE56B6D00641DB4 /* Pods_PropertyInjector_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -213,6 +213,7 @@
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
+						DevelopmentTeam = YBCCTWH2WW;
 						LastSwiftMigration = 0900;
 					};
 					607FACE41AFB9204008FA782 = {
@@ -477,8 +478,9 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4553FB0CDCD40B191E3E5018 /* Pods-PropertyInjector_Example.debug.xcconfig */;
 			buildSettings = {
+				DEVELOPMENT_TEAM = YBCCTWH2WW;
 				INFOPLIST_FILE = PropertyInjector/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
@@ -492,8 +494,9 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B41BD6F007D0F2ED7994DE46 /* Pods-PropertyInjector_Example.release.xcconfig */;
 			buildSettings = {
+				DEVELOPMENT_TEAM = YBCCTWH2WW;
 				INFOPLIST_FILE = PropertyInjector/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
@@ -516,6 +519,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -534,6 +538,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Example/Tests/PropertyInjectorTests.swift
+++ b/Example/Tests/PropertyInjectorTests.swift
@@ -23,57 +23,58 @@ class MockService: Service {
 }
 
 class PropertyInjectorTests: QuickSpec {
-    override func spec() {
-        
+    
+    override class func spec() {
+
         beforeEach {
             DependencyResolver.clear()
         }
-        
+
         describe("resolving") {
 
             it("protocol") {
                 DependencyResolver.register {
                     $0.singleton(Useful.self, Service())
                 }
-                
+
                 let service: Useful = DependencyResolver.resolve()
-                
+
                 expect(service).to(beAKindOf(Useful.self))
                 expect(service).to(beAKindOf(Service.self))
             }
-            
+
             it("class") {
                 DependencyResolver.register {
                     $0.factory(Service.self, Service())
                 }
-                
+
                 let service: Service = DependencyResolver.resolve()
 
                 expect(service).to(beAKindOf(Service.self))
             }
-            
+
             it("class using shortcut method") {
                 DependencyResolver.register {
                     $0.factory(Service())
                 }
-                
+
                 let service: Service = DependencyResolver.resolve()
 
                 expect(service).to(beAKindOf(Service.self))
             }
-            
+
             it("works for optionals too") {
                 DependencyResolver.register {
                     $0.factory(Service())
                 }
-                
+
                 let service: Service? = DependencyResolver.resolve()
                 let service2: Service! = DependencyResolver.resolve()
 
                 expect(service).to(beAKindOf(Service.self))
                 expect(service2).to(beAKindOf(Service.self))
             }
-            
+
             it("mocked dependencies") {
                 DependencyResolver.register {
                     $0.singleton(Service.self, Service())
@@ -81,45 +82,45 @@ class PropertyInjectorTests: QuickSpec {
                 DependencyResolver.register {
                     $0.singleton(Service.self, MockService())
                 }
-                
+
                 let service: Service = DependencyResolver.resolve()
 
                 expect(service).to(beAKindOf(MockService.self))
                 expect(service.getValue()).to(equal(MockService.anotherValue))
             }
-            
+
             it("crashes if the dependency is not registered") {
-                expect(expression: { () -> Void in
+                expect({ () -> Void in
                     let _: Service = DependencyResolver.resolve()
                 }).to(throwAssertion())
             }
-            
+
         }
-        
+
         describe("resolution strategy is correct for") {
 
             it("singleton") {
                 DependencyResolver.register {
-                    $0.singleton(Useful.self, Service())
+                    $0.singleton(Service.self, Service())
                 }
-                
-                let service1: Useful = DependencyResolver.resolve()
-                let service2: Useful = DependencyResolver.resolve()
-                
+
+                let service1: Service = DependencyResolver.resolve()
+                let service2: Service = DependencyResolver.resolve()
+
                 expect(service1) === service2
             }
-            
+
             it("factory") {
                 DependencyResolver.register {
-                    $0.factory(Useful.self, Service())
+                    $0.factory(Service.self, Service())
                 }
-                
-                let service1: Useful = DependencyResolver.resolve()
-                let service2: Useful = DependencyResolver.resolve()
-                
+
+                let service1: Service = DependencyResolver.resolve()
+                let service2: Service = DependencyResolver.resolve()
+
                 expect(service1) !== service2
             }
-            
+
         }
     }
 }

--- a/PropertyInjector.podspec
+++ b/PropertyInjector.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'PropertyInjector'
-  s.version          = '0.0.10'
+  s.version          = '0.0.11'
   s.summary          = 'Property dependency injection framework for Swift.'
 
 # This description is used to generate tags and improve search results.
@@ -26,7 +26,7 @@ Declare your dependencies and use them as properties in your classes.
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Stan Feldman' => 'stanislavfeldman@gmail.com' }
   s.source           = { :git => 'https://github.com/stanfeldman/PropertyInjector.git', :tag => s.version.to_s }
-  s.swift_version = '5.1'
-  s.ios.deployment_target = '11.0'
+  s.swift_version = '5.5'
+  s.ios.deployment_target = '13.0'
   s.source_files = 'PropertyInjector/Classes/**/*'
 end

--- a/PropertyInjector/Classes/Resolution/DependencyResolver.swift
+++ b/PropertyInjector/Classes/Resolution/DependencyResolver.swift
@@ -12,7 +12,7 @@
  }
  ```
  */
-public class DependencyResolver {
+public actor DependencyResolver {
     
     private static var dependencyDefinitions = [String: DependencyDefinition]()
     private static var dependencyDefinitionsWithParameters = [String: DependencyDefinitionWithParameters]()


### PR DESCRIPTION
>**Note**
>Not ready to merge, still testing

### Changes
We've had some issues that seem to be related to concurrent access of the `DependencyResolver.sharedInstances` dictionary. So I changed `DependencyResolver` to an `actor` as it's designed to regulate access to shared state. 

After increasing the deployment target to iOS 13, tests no longer ran due to the removal of a dependency inside Nimble. So I also bumped Nimble and Quick, and fixed the tests. 